### PR TITLE
Fix back handler on settings screen

### DIFF
--- a/app/src/main/kotlin/cafe/adriel/chroma/view/tuner/TunerScreen.kt
+++ b/app/src/main/kotlin/cafe/adriel/chroma/view/tuner/TunerScreen.kt
@@ -1,5 +1,7 @@
 package cafe.adriel.chroma.view.tuner
 
+import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -74,6 +76,14 @@ class TunerScreen(
         val scaffoldState = rememberBackdropScaffoldState(BackdropValue.Revealed)
         val scope = rememberCoroutineScope()
         val context = LocalContext.current
+
+        BackHandler {
+            if (scaffoldState.isConcealed) {
+                scaffoldState.toggle(scope)
+                return@BackHandler
+            }
+            (context as Activity).finish()
+        }
 
         ChromaTheme {
             BackdropScaffold(


### PR DESCRIPTION
Hi fellow developer,

I've been enjoying using the app, especially as an amateur violin player—it's really useful! I couldn't resist the urge to contribute and improve the user experience. I noticed a behavior on the settings screen: when we tap the back button, it exits the app. This is the default behavior since the settings screen is technically the front layer of a BackdropScaffold, not a separate screen. To address this, I've implemented a BackHandler to ensure that tapping the back button or performing the back gesture on the settings screen will now properly hide the front layer.

Cheers,
Before:
https://github.com/adrielcafe/chroma/assets/9391366/e614151e-924e-4c77-9bb3-3b96453175a6

After:
https://github.com/adrielcafe/chroma/assets/9391366/46b9b148-83ad-49b6-a9cc-3fd0db4afc3e


